### PR TITLE
- El mensaje #rollDiceFor: ya no se usa en los tests, se utiliza un n…

### DIFF
--- a/repository/IngSoft2-Model/LaScalonetaGame.class.st
+++ b/repository/IngSoft2-Model/LaScalonetaGame.class.st
@@ -100,6 +100,12 @@ LaScalonetaGame >> nextSpaceShipTurn: aSpaceShip [
 	spaceShipTurn := (spaceShips  first)
 ]
 
+{ #category : #playing }
+LaScalonetaGame >> playNextTurn [
+
+	self rollDiceCupFor: (self spaceShipTurn)
+]
+
 { #category : #accessing }
 LaScalonetaGame >> positionOf: aSpaceShip [
 

--- a/repository/IngSoft2-Tests/LaScalonetaGameTest.class.st
+++ b/repository/IngSoft2-Tests/LaScalonetaGameTest.class.st
@@ -32,76 +32,6 @@ LaScalonetaGameTest >> should: block raise: expectedErrorClass withMessage: expe
 ]
 
 { #category : #running }
-LaScalonetaGameTest >> testAfterLastPlayersTurnItsPlayer1TurnAgain [
-
-	| aGame aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: { 'aTile1'. 'aTile2'. 'aTile3' }.
-	
-	aDie1 := LoadedDie with: 1.
-	aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Player1'. 'Player2'. 'LastPlayer'} )
-				on: aBoard
-				rolling: aDiceCup.
-
-	aGame rollDiceCupFor: 'Player1'.
-	aGame rollDiceCupFor: 'Player2'.
-	aGame rollDiceCupFor: 'LastPlayer'.
-	
-	self assert: ( aGame positionOf: 'Player1' ) tileNumber equals: 2.
-	self assert: ( aGame positionOf: 'Player2' ) tileNumber equals: 2.
-	self assert: ( aGame positionOf: 'LastPlayer' ) tileNumber equals: 2.
-	self assert:  aGame spaceShipTurn equals: 'Player1'.
-	self assert: ( aGame itsMyTurn: 'Player1' )
-]
-
-{ #category : #running }
-LaScalonetaGameTest >> testAfterPlayer1ItsNotPlayer3Turn [
-
-	| aGame aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: { 'aTile1'. 'aTile2'. 'aTile3' }.
-	
-	aDie1 := LoadedDie with: 1.
-	aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Player1'. 'Player2'. 'LastPlayer'} )
-				on: aBoard
-				rolling: aDiceCup.
-	
-	aGame rollDiceCupFor: 'Player1'.
-	
-	self assert: ( aGame positionOf: 'Player1' ) tileNumber equals: 2.
-	self deny:  aGame spaceShipTurn equals: 'Player3'.
-	self assert: ( aGame itsMyTurn: 'Player2' )
-]
-
-{ #category : #running }
-LaScalonetaGameTest >> testAfterPlayer1ItsPlayer2Turn [
-
-	| aGame aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: { 'aTile1'. 'aTile2'. 'aTile3' }.
-	
-	aDie1 := LoadedDie with: 1.
-	aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Player1'. 'Player2'. 'LastPlayer'} )
-				on: aBoard
-				rolling: aDiceCup.
-	
-	aGame rollDiceCupFor: 'Player1'.
-	
-	self assert: ( aGame positionOf: 'Player1' ) tileNumber equals: 2.
-	self assert:  aGame spaceShipTurn equals: 'Player2'.
-	self deny: ( aGame itsMyTurn: 'Player3' )
-]
-
-{ #category : #running }
 LaScalonetaGameTest >> testFinalPositionOfPlayersCorrespondsWithTheActualFinalPositions [
 
 	| aGame aBoard aDie1 aDiceCup |
@@ -116,12 +46,11 @@ LaScalonetaGameTest >> testFinalPositionOfPlayersCorrespondsWithTheActualFinalPo
 				on: aBoard
 				rolling: aDiceCup.
 
-	aGame rollDiceCupFor: 'Jorge'.
-	aGame rollDiceCupFor: 'Julian'.
-	aGame rollDiceCupFor: 'Chango'.
-	aGame rollDiceCupFor: 'Jorge'.
+	aGame playNextTurn. 
+	aGame playNextTurn. 
+	aGame playNextTurn. 
+	aGame playNextTurn. 
 
-	
 	self assert: (aGame hasEnded).
 	self assert: ( aGame positionOf: 'Jorge' ) tileNumber equals: 3.
 	self assert: ( aGame positionOf: 'Julian' ) tileNumber equals: 2.
@@ -138,13 +67,13 @@ LaScalonetaGameTest >> testGameHasEndedAsOnePlayerReachedTheEnd [
 	self deny: (aGame hasEnded).
 
 			
-	aGame rollDiceCupFor: 'Jorge'.
-	aGame rollDiceCupFor: 'Julian'.	
+	aGame playNextTurn. 
+	aGame playNextTurn. 
 		
 	self deny: (aGame hasEnded).
 
 	
-	aGame rollDiceCupFor: 'Jorge'.
+	aGame playNextTurn. 
 	
 	self assert: aGame hasEnded.
 	self assert: ((aGame positionOf: 'Jorge') tileNumber) equals: aGame board tiles size
@@ -154,7 +83,7 @@ LaScalonetaGameTest >> testGameHasEndedAsOnePlayerReachedTheEnd [
 
 { #category : #tests }
 LaScalonetaGameTest >> testGameHasNotEndedAsNoPlayerReachedTheEnd [
-
+	
 	| aGame |
 	
 	aGame := self initializeLaScalonetaGame.
@@ -163,7 +92,7 @@ LaScalonetaGameTest >> testGameHasNotEndedAsNoPlayerReachedTheEnd [
 	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 1.
 	self assert: (aGame positionOf: 'Julian') tileNumber equals: 1.
 	
-	aGame rollDiceCupFor: 'Jorge'.
+	aGame playNextTurn. 
 	
 	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 2.
 	self deny: aGame hasEnded
@@ -194,7 +123,7 @@ LaScalonetaGameTest >> testJorgeIsNotTheWinnerOfLaScalonetaGameWhenJulianReaches
 				on: aBoard
 				rolling: aDiceCup.
 
-	 aGame rollDiceCupFor: 'Julian'.
+	 aGame playNextTurn. 
 	
 	 self deny: aGame winner equals: 'Jorge'
 	
@@ -205,16 +134,6 @@ LaScalonetaGameTest >> testJorgeIsNotTheWinnerOfLaScalonetaGameWhenJulianReaches
 	
 	
 
-]
-
-{ #category : #running }
-LaScalonetaGameTest >> testJorgeStartsTheGameAsHeIsTheFirstPlayerInThePlayersCollection [
-	
-	| aGame |
-
-	aGame := self initializeLaScalonetaGame.
-	
-	self assert: aGame spaceShipTurn equals: 'Jorge'
 ]
 
 { #category : #tests }
@@ -232,7 +151,7 @@ LaScalonetaGameTest >> testJorgeWinsLaScalonetaGameWhenJorgeReachesTheEndFirst [
 				on: aBoard
 				rolling: aDiceCup.
 
-	 aGame rollDiceCupFor: 'Jorge'.
+	 aGame playNextTurn.
 	
 	 self assert: aGame winner equals: 'Jorge'
 	
@@ -243,31 +162,6 @@ LaScalonetaGameTest >> testJorgeWinsLaScalonetaGameWhenJorgeReachesTheEndFirst [
 	
 	
 
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testJulianCanNotRollTheDiceWhenIsNotHisTurn [
-
-	| aGame |
-
-	aGame := self initializeLaScalonetaGame.
-				
-	self
-		should: [aGame rollDiceCupFor: 'Julian']
-		raise: Error
-		withMessage: 'Its not your turn!'
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testJulianCanRollTheDiceAfterJorge [
-
-	| aGame |
-
-	aGame := self initializeLaScalonetaGame.
-	
-	aGame rollDiceCupFor: 'Jorge'.
-	
-	self assert: aGame spaceShipTurn equals: 'Julian'
 ]
 
 { #category : #tests }
@@ -306,7 +200,7 @@ LaScalonetaGameTest >> testPlayerMovesThreeTilesFowardWhenRollingResultEqualsToT
 				on: aBoard
 				rolling: aDiceCup.
 				
-	aGame rollDiceCupFor: 'Jorge'. 	
+	aGame playNextTurn.  	
 
 	self assert: ( aGame positionOf: 'Jorge' ) tileNumber equals: 4.	
 				
@@ -342,14 +236,14 @@ LaScalonetaGameTest >> testPlayingAfterWinningIsNotAllowed [
 	self assert: ( aGame positionOf: 'Jorge' ) tileNumber equals: 1.	
 	self assert: ( aGame positionOf: 'Julian' ) tileNumber equals: 1.	
 			
-	aGame rollDiceCupFor: 'Jorge'. 	
+	aGame playNextTurn. 	
 		
 	self assert: (aGame hasEnded).
 	self assert: ( aGame positionOf: 'Jorge' ) tileNumber equals: 3.	
 	self assert: ( aGame positionOf: 'Julian' ) tileNumber equals: 1.
 	
 	self
-		should: [aGame rollDiceCupFor: 'Julian']
+		should: [aGame playNextTurn]
 		raise: Error
 		withMessage: 'La Scaloneta Game has already ended!'
 ]
@@ -361,7 +255,7 @@ LaScalonetaGameTest >> testThereIsNoWinnerAsTheGameHasNotEnded [
 
 	aGame := self initializeLaScalonetaGame.
 
-	aGame rollDiceCupFor: 'Jorge'.
+	aGame playNextTurn.
 	
 	self
 		should: [ 


### PR DESCRIPTION
…uevo mensaje #playNextTurn, con esto evitamos tener que pasarle el jugador que quiere tirar y delegamos en el juego el saber quien debe seguir.

- Eliminamos los tests que verificaban todo lo relacionado con los turnos.