### PR TITLE
Formateo de codigo,  se agregan tests para HyperJumpEffect y SpaceShi…

### DIFF
--- a/repository/IngSoft2-Model/AtomicBombEffect.class.st
+++ b/repository/IngSoft2-Model/AtomicBombEffect.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #private }
 AtomicBombEffect >> moveSpaceShip: aSpaceShips for: aGame [
-		
-		
-		^ (aSpaceShips  do: [ :spaceShip | aGame moveSpaceShipToFirstPositionOnSameLap: spaceShip ]) 
+
+	^ aSpaceShips do: [ :spaceShip | 
+		  aGame moveSpaceShipToFirstPositionOnSameLap: spaceShip ]
 ]

--- a/repository/IngSoft2-Model/Board.class.st
+++ b/repository/IngSoft2-Model/Board.class.st
@@ -9,16 +9,17 @@ Class {
 }
 
 { #category : #asserting }
-Board class >> assertValid: aTileCollection [ 
+Board class >> assertValid: aTileCollection [
 
-	aTileCollection size  < 2 ifTrue: [ Error signal: 'Number of tiles should be 2 or more' ]
+	aTileCollection size < 2 ifTrue: [ 
+		Error signal: 'Number of tiles should be 2 or more' ]
 ]
 
 { #category : #'instance creation' }
-Board class >> withTiles: aTileCollection andParsecs: aParsecs [
+Board class >> withTiles: tiles andParsecs: parsecs [
 
-	self assertValid: aTileCollection.
-	^ self new initializeWithTiles: aTileCollection andParsecs: aParsecs 
+	self assertValid: tiles.
+	^ self new initializeWithTiles: tiles andParsecs: parsecs
 ]
 
 { #category : #accessing }
@@ -37,8 +38,9 @@ Board >> initializeWithTiles: aTileCollection andParsecs: aParsecs [
 { #category : #asserting }
 Board >> isTheLastOnePosition: aPosition [
 
-	( self lastPosition = aPosition ) ifTrue:[ ^ true ]
-									         ifFalse: [ ^ false ]
+	self lastPosition = aPosition
+		ifTrue: [ ^ true ]
+		ifFalse: [ ^ false ]
 ]
 
 { #category : #accessing }

--- a/repository/IngSoft2-Model/DiceCup.class.st
+++ b/repository/IngSoft2-Model/DiceCup.class.st
@@ -10,14 +10,15 @@ Class {
 { #category : #asserting }
 DiceCup class >> assertValid: aDiceCollection [
 
-	aDiceCollection size < 1 ifTrue: [ Error signal: 'A DiceCup should have at least one die.' ]
+	aDiceCollection ifEmpty: [ 
+		Error signal: 'A DiceCup should have at least one die.' ]
 ]
 
 { #category : #'instance creation' }
 DiceCup class >> withAll: dice [
 
-		self assertValid: dice.
-      ^ self new initializeWithAll: dice
+	self assertValid: dice.
+	^ self new initializeWithAll: dice
 ]
 
 { #category : #initialization }
@@ -29,6 +30,5 @@ DiceCup >> initializeWithAll: aDice [
 { #category : #rolling }
 DiceCup >> roll [
 
-      ^ dice sum: [:die | die roll ]
-
+	^ dice sum: [ :die | die roll ]
 ]

--- a/repository/IngSoft2-Model/EffectPool.class.st
+++ b/repository/IngSoft2-Model/EffectPool.class.st
@@ -8,8 +8,11 @@ Class {
 }
 
 { #category : #initialize }
-EffectPool class >> withEffects: effectsCollection andProbabilities: probabilitiesCollection [
-	^self new initializeWithEffect: effectsCollection andProbabilities: probabilitiesCollection.
+EffectPool class >> withEffects: effects andProbabilities: probabilities [
+
+	^ self new
+		  initializeWithEffect: effects
+		  andProbabilities: probabilities
 ]
 
 { #category : #accessing }
@@ -19,37 +22,36 @@ EffectPool >> effectPoolCollection [
 ]
 
 { #category : #initialization }
-EffectPool >> initializeWithEffect: effects andProbabilities: probabilities [ 
+EffectPool >> initializeWithEffect: effects andProbabilities: probabilities [
 
-		| effect probability |
+	| effect probability |
+	effectPoolCollection := {  }.
 
-      effectPoolCollection := {}.
-		
-		1 to: effects size do: [ :i | effect := effects at: i.
-                                    probability := probabilities at: i.
+	1 to: effects size do: [ :i | 
+		effect := effects at: i.
+		probability := probabilities at: i.
 
-                                    probability+1 timesRepeat: [ effectPoolCollection := effectPoolCollection copyWith: effect. ]                                                       
-									 ]
+		probability + 1 timesRepeat: [ 
+			effectPoolCollection := effectPoolCollection copyWith: effect ] ]
 ]
 
 { #category : #accessing }
 EffectPool >> randomCollectionOfEffectsWithLength: length [
 
 	| randomEffectsCollection |
+	randomEffectsCollection := {  }.
 
-	randomEffectsCollection :=  { }.
-	
-	1 to: length do: [ :i | randomEffectsCollection :=  randomEffectsCollection copyWith: self randomEffect].
-	
-	^ randomEffectsCollection.
-	
+	1 to: length do: [ :i | 
+		randomEffectsCollection := randomEffectsCollection copyWith:
+			                           self randomEffect ].
+
+	^ randomEffectsCollection
 ]
 
 { #category : #accessing }
 EffectPool >> randomEffect [
 
-	|effectIndex|
-       
-		effectIndex := (effectPoolCollection size) atRandom.
-		^ self effectPoolCollection at: effectIndex .
+	| effectIndex |
+	effectIndex := effectPoolCollection size atRandom.
+	^ self effectPoolCollection at: effectIndex
 ]

--- a/repository/IngSoft2-Model/HyperJumpEffect.class.st
+++ b/repository/IngSoft2-Model/HyperJumpEffect.class.st
@@ -8,17 +8,25 @@ Class {
 }
 
 { #category : #asserting }
-HyperJumpEffect class >> assertValidCollection: aCollecrtionOfM [
-	
-	aCollecrtionOfM do: [ : m | m<0 ifTrue:[Error signal: 'Values of the collection must be positive!' ]]
+HyperJumpEffect class >> assertIsNotEmptyFor: aCollecrtionOfM [
+
+	aCollecrtionOfM ifEmpty: [ Error signal: 'HyperJumpEffect can not be initalize with empty collection!' ] 
+]
+
+{ #category : #asserting }
+HyperJumpEffect class >> assertValidValuesFor: aCollecrtionOfM [
+
+	aCollecrtionOfM do: [ :m | 
+		m < 0 ifTrue: [ 
+			Error signal: 'Values of the collection must be positive!' ] ]
 ]
 
 { #category : #'instance creation' }
-HyperJumpEffect class >> with: aCollectionOfM [
-	
-	self assertValidCollection: aCollectionOfM.
-	^self new initializeWith: aCollectionOfM. 
-	
+HyperJumpEffect class >> withMValues: aCollectionOfM [
+
+	self assertIsNotEmptyFor: aCollectionOfM.
+	self assertValidValuesFor: aCollectionOfM.
+	^ self new initializeWith: aCollectionOfM
 ]
 
 { #category : #private }
@@ -38,12 +46,17 @@ HyperJumpEffect >> initializeWith: aCollectionOfM [
 
 { #category : #private }
 HyperJumpEffect >> moveSpaceShip: aSpaceShips for: aGame [
-		
-		| value_MCollection |
-		
-		value_MCollection := self collectionOfM first.
-		
-		collectionOfM  := ((self collectionOfM) reject: [ :each | each = value_MCollection ]) , { value_MCollection }.
-	
-		^ aGame moveSpaceShip: (aSpaceShips first) withRollingResult: (value_MCollection / (aGame board parsecs / aGame board tiles size )) floor 
+
+	| value_MCollection |
+	value_MCollection := self collectionOfM first.
+
+	collectionOfM := (self collectionOfM reject: [ :each | 
+		                  each = value_MCollection ])
+	                 , { value_MCollection }.
+
+	^ aGame
+		  moveSpaceShip: aSpaceShips first
+		  withRollingResult:
+			  (value_MCollection
+			   / (aGame board parsecs / aGame board tiles size)) floor
 ]

--- a/repository/IngSoft2-Model/LaScalonetaGame.class.st
+++ b/repository/IngSoft2-Model/LaScalonetaGame.class.st
@@ -7,7 +7,7 @@ Class {
 		'spaceShips',
 		'hasEnded',
 		'spaceShipPositions',
-		'spaceShipTurn',
+		'spaceShipCurrentTurn',
 		'laps'
 	],
 	#category : #'IngSoft2-Model'
@@ -16,28 +16,28 @@ Class {
 { #category : #asserting }
 LaScalonetaGame class >> assertValidNumberOfLaps: aLaps [
 
-		(aLaps <= 1) ifTrue: [ Error signal: 'La Scaloneta Game must have two or more laps!' ]
+	aLaps > 0 ifFalse: [ 
+		Error signal: 'La Scaloneta Game must have one or more laps!' ]
 ]
 
 { #category : #asserting }
 LaScalonetaGame class >> assertValidNumberOfSpaceShips: aSpaceShipsCollection [
 
-		aSpaceShipsCollection isEmpty ifTrue: [ Error signal: 'La Scaloneta Game must have at least one spaceship!' ]
+	aSpaceShipsCollection isEmpty ifTrue: [ 
+		Error signal: 'La Scaloneta Game must have at least one spaceship!' ]
 ]
 
 { #category : #'instance creation' }
-LaScalonetaGame class >> playedBy: aSpaceShips on: aBoard rolling: aDiceCollection numberOfLaps: aLaps [
+LaScalonetaGame class >> playedBy: spaceShips on: board rolling: dice withNumberOfLaps: laps [
 
-	self assertValidNumberOfSpaceShips: aSpaceShips.
-	self assertValidNumberOfLaps: aLaps.
+	self assertValidNumberOfSpaceShips: spaceShips.
+	self assertValidNumberOfLaps: laps.
 
 	^ self new
-				initializeWithBoard: aBoard
-				diceCollection: aDiceCollection
-				spaceShips: aSpaceShips
-				numberOfLaps: aLaps
-
-				
+		  initializeWithBoard: board
+		  diceCollection: dice
+		  spaceShips: spaceShips
+		  numberOfLaps: laps
 ]
 
 { #category : #adding }
@@ -49,20 +49,23 @@ LaScalonetaGame >> addPosition: aSpaceShipPosition [
 { #category : #private }
 LaScalonetaGame >> applyEffect: aSpaceShips [
 
-	(self board tiles at:
-	      (self positionOf: (aSpaceShips  first)) tileNumber ) moveSpaceShip: aSpaceShips for: self. 
+	(self board tiles at: (self positionOf: aSpaceShips first) tileNumber)
+		moveSpaceShip: aSpaceShips
+		for: self
 ]
 
 { #category : #asserting }
 LaScalonetaGame >> assertGameHasNotEnded [
 
-	(self hasEnded) ifTrue: [ Error signal: 'La Scaloneta Game has already ended!' ]
+	self hasEnded ifTrue: [ 
+		Error signal: 'La Scaloneta Game has already ended!' ]
 ]
 
 { #category : #asserting }
-LaScalonetaGame >> assertItsMyTurn: aPlayer [
+LaScalonetaGame >> assertSpaceShipTurn: aSpaceShip [
 
-	(self itsMyTurn: aPlayer) ifFalse: [ Error signal: 'Its not your turn!' ]
+	self spaceShipCurrentTurn = aSpaceShip ifFalse: [ 
+		Error signal: 'Its not your turn!' ]
 ]
 
 { #category : #accessing }
@@ -84,16 +87,13 @@ LaScalonetaGame >> initializeWithBoard: aBoard diceCollection: aDiceCollection s
 	diceCollection := aDiceCollection.
 	spaceShips := aSpaceShip.
 	hasEnded := false.
-	spaceShipPositions := ( spaceShips collect: [ :player | (SpaceShipPosition startingOfSpaceShip: player forBoard: board lap: 1) ] ) asOrderedCollection.
-	spaceShipTurn := (spaceShips first).
+	spaceShipPositions := (spaceShips collect: [ :player | 
+		                       SpaceShipPosition
+			                       startingOfSpaceShip: player
+			                       forBoard: board
+			                       lap: 1 ]) asOrderedCollection.
+	spaceShipCurrentTurn := spaceShips first.
 	laps := aLaps
-]
-
-{ #category : #playing }
-LaScalonetaGame >> itsMyTurn: aSpaceShip [
-
-	(spaceShipTurn = aSpaceShip) ifTrue: [ ^ true ]
-	                             ifFalse: [ ^ false ]
 ]
 
 { #category : #accessing }
@@ -105,95 +105,97 @@ LaScalonetaGame >> laps [
 { #category : #private }
 LaScalonetaGame >> moveSpaceShip: aSpaceShip withRollingResult: aResult [
 
-	| quantityOfSquaresAdvanced auxLap newLap newPosition |
-	
-	quantityOfSquaresAdvanced  :=  (((self positionOf: aSpaceShip) lap - 1) * (self board tiles size)) + aResult + (self positionOf: aSpaceShip) tileNumber.
-	
-	quantityOfSquaresAdvanced <= 0 ifTrue:[quantityOfSquaresAdvanced := 1].
-	
-	auxLap := ((quantityOfSquaresAdvanced - 1)  // (self board tiles size) + 1).
-	
-	newLap := auxLap min: (self laps).
-	
-	newPosition := quantityOfSquaresAdvanced % (self board tiles size).
-	
-	(newPosition = 0 | (auxLap > (self laps))) ifTrue: [ newPosition := (self board tiles size)].
-	
- 	self addPosition: ( SpaceShipPosition
-								ofSpaceShip: ( (self positionOf: aSpaceShip) spaceShip )
-								tileNumber: newPosition
-								lap: newLap
-							) 
-							
-						
+	| quantityOfSquaresAdvanced auxLap newLap newPosition oldPosition boardSize |
+	oldPosition := self positionOf: aSpaceShip.
+	boardSize := self board tiles size.
+
+	quantityOfSquaresAdvanced := (oldPosition lap - 1) * boardSize
+	                             + aResult + oldPosition tileNumber.
+
+	quantityOfSquaresAdvanced <= 0 ifTrue: [ 
+		quantityOfSquaresAdvanced := 1 ].
+
+	auxLap := quantityOfSquaresAdvanced - 1 // boardSize + 1.
+
+	newLap := auxLap min: self laps.
+
+	newPosition := quantityOfSquaresAdvanced % boardSize.
+
+	(newPosition = 0 or: [ auxLap > self laps ]) ifTrue: [ 
+		newPosition := boardSize ].
+
+	self addPosition: (SpaceShipPosition
+			 ofSpaceShip: oldPosition spaceShip
+			 tileNumber: newPosition
+			 lap: newLap)
 ]
 
 { #category : #private }
-LaScalonetaGame >> moveSpaceShipToFirstPositionOnSameLap: aSpaceShip [ 
+LaScalonetaGame >> moveSpaceShipToFirstPositionOnSameLap: aSpaceShip [
 
- 	self addPosition: ( SpaceShipPosition
-								ofSpaceShip: ( (self positionOf: aSpaceShip) spaceShip )
-								tileNumber: board firstPosition 
-								lap: (self positionOf: aSpaceShip ) lap
-							) 
+	self addPosition: (SpaceShipPosition
+			 ofSpaceShip: (self positionOf: aSpaceShip) spaceShip
+			 tileNumber: board firstPosition
+			 lap: (self positionOf: aSpaceShip) lap)
 ]
 
 { #category : #playing }
 LaScalonetaGame >> nextSpaceShipTurn: aSpaceShip [
 
-	spaceShips := (spaceShips reject: [ :each | each = aSpaceShip ]) , { aSpaceShip }.
+	spaceShips := (spaceShips reject: [ :each | each = aSpaceShip ])
+	              , { aSpaceShip }.
 
-	spaceShipTurn := (spaceShips  first)
+	spaceShipCurrentTurn := spaceShips first
 ]
 
 { #category : #playing }
 LaScalonetaGame >> playNextTurn [
 
-	self playTurnFor: (self spaceShipTurn)
+	self playTurnFor: self spaceShipCurrentTurn
 ]
 
 { #category : #private }
-LaScalonetaGame >> playTurnFor: aPlayer [
+LaScalonetaGame >> playTurnFor: aSpaceShip [
 
 	| rollingResult |
-	
-	self assertItsMyTurn: aPlayer.
+	self assertSpaceShipTurn: aSpaceShip.
 	self assertGameHasNotEnded.
-	
+
 	rollingResult := diceCollection roll.
-	
-	self moveSpaceShip: aPlayer withRollingResult: rollingResult.
 
-	(board isTheLastOnePosition:( (self positionOf: aPlayer) tileNumber )) & ((self positionOf: aPlayer) lap = (self laps)) ifTrue: [ hasEnded := true ]
-																																								ifFalse: [ self applyEffect: self spaceShips.
-																																									        self nextSpaceShipTurn: aPlayer.]
-							
-																																												
+	self moveSpaceShip: aSpaceShip withRollingResult: rollingResult.
 
+	((board isTheLastOnePosition:
+		  (self positionOf: aSpaceShip) tileNumber) and: [ 
+		 (self positionOf: aSpaceShip) lap = self laps ])
+		ifTrue: [ hasEnded := true ]
+		ifFalse: [ 
+			self applyEffect: self spaceShips.
+			self nextSpaceShipTurn: aSpaceShip ]
 ]
 
 { #category : #accessing }
 LaScalonetaGame >> positionOf: aSpaceShip [
 
-	^ (spaceShipPositions select: [ :position | position spaceShip = aSpaceShip ]) last
+	^ (spaceShipPositions select: [ :position | 
+		   position spaceShip = aSpaceShip ]) last
 ]
 
 { #category : #classification }
 LaScalonetaGame >> positionsRanking [
 
 	| spaceShipsPositions |
+	spaceShipsPositions := self spaceShips collect: [ :aSpaceShip | 
+		                       self positionOf: aSpaceShip ].
 
-	spaceShipsPositions := (self spaceShips) collect: [ :aSpaceShip | self positionOf: aSpaceShip].
- 
-	^ spaceShipsPositions asSortedCollection: [ :spaceShipA :spaceShipB | spaceShipA >= spaceShipB ]
-
-
+	^ spaceShipsPositions asSortedCollection: [ :spaceShipA :spaceShipB | 
+		  spaceShipA >= spaceShipB ]
 ]
 
 { #category : #accessing }
-LaScalonetaGame >> spaceShipTurn [
+LaScalonetaGame >> spaceShipCurrentTurn [
 	
-	^ spaceShipTurn
+	^ spaceShipCurrentTurn
 ]
 
 { #category : #accessing }
@@ -207,11 +209,12 @@ LaScalonetaGame >> spaceShips [
 LaScalonetaGame >> winner [
 
 	| aWinner |
-	
-	aWinner:= (spaceShips select: [ :spaceShip | (self positionOf: spaceShip)tileNumber >= (self board lastPosition) ]).
-	
-	aWinner size < 1 ifTrue: [ Error signal: 'There is no winner as the game has not ended yet.' ]
-	
-	ifFalse: [^ aWinner last ]
-	
+	aWinner := spaceShips select: [ :spaceShip | 
+		           (self positionOf: spaceShip) tileNumber
+		           >= self board lastPosition ].
+
+	aWinner size < 1
+		ifTrue: [ 
+		Error signal: 'There is no winner as the game has not ended yet.' ]
+		ifFalse: [ ^ aWinner last ]
 ]

--- a/repository/IngSoft2-Model/LoadedDie.class.st
+++ b/repository/IngSoft2-Model/LoadedDie.class.st
@@ -10,14 +10,15 @@ Class {
 { #category : #asserting }
 LoadedDie class >> assertValid: result [
 
-	result > 0 ifFalse: [ Error signal: 'Die should be loaded with result greater than zero' ] 
+	result > 0 ifFalse: [ 
+		Error signal: 'Die should be loaded with result greater than zero' ]
 ]
 
 { #category : #'instance creation' }
 LoadedDie class >> with: result [
 
 	self assertValid: result.
-	^self new initializeWith: result
+	^ self new initializeWith: result
 ]
 
 { #category : #initialization }

--- a/repository/IngSoft2-Model/MoonWalkEffect.class.st
+++ b/repository/IngSoft2-Model/MoonWalkEffect.class.st
@@ -10,13 +10,15 @@ Class {
 { #category : #asserting }
 MoonWalkEffect class >> assertNIsANegativeNumber: aN [
 
-	aN > 0 ifTrue: [ Error signal: 'MoonWalk effect N must be a negative number' ]
+	aN > 0 ifTrue: [ 
+		Error signal: 'MoonWalk effect N must be a negative number' ]
 ]
 
 { #category : #private }
 MoonWalkEffect class >> withN: aN [
+
 	self assertNIsANegativeNumber: aN.
-	^self new initializeWith: aN.
+	^ self new initializeWith: aN
 ]
 
 { #category : #initialization }
@@ -27,9 +29,9 @@ MoonWalkEffect >> initializeWith: aN [
 
 { #category : #private }
 MoonWalkEffect >> moveSpaceShip: aSpaceShips for: aGame [
-		
-		
-		^(aSpaceShips allButFirst do: [ :spaceShip | aGame moveSpaceShip: spaceShip  withRollingResult: self n ]) 
+
+	^ aSpaceShips allButFirst do: [ :spaceShip | 
+		  aGame moveSpaceShip: spaceShip withRollingResult: self n ]
 ]
 
 { #category : #accessing }

--- a/repository/IngSoft2-Model/NoEffect.class.st
+++ b/repository/IngSoft2-Model/NoEffect.class.st
@@ -6,6 +6,6 @@ Class {
 
 { #category : #private }
 NoEffect >> moveSpaceShip: aSpaceShips for: aGame [
-		
-		^ aGame moveSpaceShip: aSpaceShips first withRollingResult: 0
+
+	^ aGame moveSpaceShip: aSpaceShips first withRollingResult: 0
 ]

--- a/repository/IngSoft2-Model/RandomDie.class.st
+++ b/repository/IngSoft2-Model/RandomDie.class.st
@@ -8,9 +8,10 @@ Class {
 }
 
 { #category : #asserting }
-RandomDie class >> assertValid: numberOfSides [ 
+RandomDie class >> assertValid: numberOfSides [
 
-	numberOfSides < 3 ifTrue: [ Error signal: 'Number of faces should be greater than 2' ]
+	numberOfSides < 3 ifTrue: [ 
+		Error signal: 'Number of faces should be greater than 2' ]
 ]
 
 { #category : #'instance creation' }
@@ -29,5 +30,5 @@ RandomDie >> initializeWith: aNumberOfSides [
 { #category : #rolling }
 RandomDie >> roll [
 
-      ^ numberOfSides atRandom
+	^ numberOfSides atRandom
 ]

--- a/repository/IngSoft2-Model/SpaceShipPosition.class.st
+++ b/repository/IngSoft2-Model/SpaceShipPosition.class.st
@@ -12,22 +12,27 @@ Class {
 { #category : #'instance creation' }
 SpaceShipPosition class >> ofSpaceShip: aSpaceSip tileNumber: aTileNumber lap: aLap [
 
-	^ self new initializeOfSpaceShip: aSpaceSip tileNumber: aTileNumber lap: aLap
-
+	^ self new
+		  initializeOfSpaceShip: aSpaceSip
+		  tileNumber: aTileNumber
+		  lap: aLap
 ]
 
 { #category : #'instance creation' }
 SpaceShipPosition class >> startingOfSpaceShip: aSpaceShip forBoard: aBoard lap: aLap [
 
-	^ self ofSpaceShip: aSpaceShip tileNumber: (aBoard firstPosition) lap: aLap
-
+	^ self
+		  ofSpaceShip: aSpaceShip
+		  tileNumber: aBoard firstPosition
+		  lap: aLap
 ]
 
 { #category : #comparing }
-SpaceShipPosition >> >= aSpaceShipPosition [ 
+SpaceShipPosition >> >= aSpaceShipPosition [
 
-	self lap = aSpaceShipPosition lap ifTrue: [ ^ self tileNumber >= aSpaceShipPosition tileNumber ].
-	^ self lap >= aSpaceShipPosition lap.
+	self lap = aSpaceShipPosition lap ifTrue: [ 
+		^ self tileNumber >= aSpaceShipPosition tileNumber ].
+	^ self lap >= aSpaceShipPosition lap
 ]
 
 { #category : #initialization }

--- a/repository/IngSoft2-Model/SpeedUpEffect.class.st
+++ b/repository/IngSoft2-Model/SpeedUpEffect.class.st
@@ -6,6 +6,6 @@ Class {
 
 { #category : #private }
 SpeedUpEffect >> moveSpaceShip: aSpaceShips for: aGame [
-		
-		^ aGame moveSpaceShip: (aSpaceShips first) withRollingResult: 4
+
+	^ aGame moveSpaceShip: aSpaceShips first withRollingResult: 4
 ]

--- a/repository/IngSoft2-Model/WormHoleEffect.class.st
+++ b/repository/IngSoft2-Model/WormHoleEffect.class.st
@@ -6,6 +6,6 @@ Class {
 
 { #category : #private }
 WormHoleEffect >> moveSpaceShip: aSpaceShips for: aGame [
-		
-		^ aGame moveSpaceShip: aSpaceShips first  withRollingResult: -4
+
+	^ aGame moveSpaceShip: aSpaceShips first withRollingResult: -4
 ]

--- a/repository/IngSoft2-Tests/BoardTest.class.st
+++ b/repository/IngSoft2-Tests/BoardTest.class.st
@@ -36,22 +36,6 @@ BoardTest >> testTileNumberedIsCorrect [
 ]
 
 { #category : #tests }
-BoardTest >> testTileNumberedIsNoyCorrect [
-
-	| tile1 tile2 tiles board |
-	
-	tile1 := NoEffect new.
-	tile2 := NoEffect new.
-	
-	tiles := {tile1. tile2}.
-
-	board := Board withTiles: tiles andParsecs: 1.
-	
-	self deny: ( board tileNumbered: 1 ) equals: tile2.
-	self deny: ( board tileNumbered: 2 ) equals: tile1.
-]
-
-{ #category : #tests }
 BoardTest >> testTilesBoardEqualsToTilesCollection [
 
 | tile1 tile2 tiles board |

--- a/repository/IngSoft2-Tests/DiceCupTest.class.st
+++ b/repository/IngSoft2-Tests/DiceCupTest.class.st
@@ -15,7 +15,7 @@ DiceCupTest >> should: block raise: expectedErrorClass withMessage: expectedErro
 ]
 
 { #category : #tests }
-DiceCupTest >> testDiceCupCanNotInitializeIfEmpty [
+DiceCupTest >> testDiceCupShouldHaveAtLeastOneDie [
 	
 	
 	self

--- a/repository/IngSoft2-Tests/LaScalonetaGameTest.class.st
+++ b/repository/IngSoft2-Tests/LaScalonetaGameTest.class.st
@@ -4,12 +4,17 @@ Class {
 	#category : #'IngSoft2-Tests'
 }
 
-{ #category : #initialization }
-LaScalonetaGameTest >> initializeLaScalonetaGame [
+{ #category : #creating }
+LaScalonetaGameTest >> laScalonetaGamePlayedByJorgeAndJulianWithALoadedDieWithOneOnABoardOfFourNoEffectTilesAndTwoParsecsDuringTwoLaps [
 
 	| aGame aDiceCup aBoard aDie1 |
-	
-	aBoard := Board withTiles: { NoEffect new. NoEffect new. NoEffect new. NoEffect new} andParsecs: 2.
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 2.
 
 	aDie1 := LoadedDie with: 1.
 	aDiceCup := DiceCup withAll: { aDie1 }.
@@ -18,14 +23,14 @@ LaScalonetaGameTest >> initializeLaScalonetaGame [
 		         playedBy: { 'Jorge'. 'Julian' }
 		         on: aBoard
 		         rolling: aDiceCup
-					numberOfLaps: 2.
+		         withNumberOfLaps: 2.
 	^ aGame
 ]
 
 { #category : #playing }
 LaScalonetaGameTest >> playUntilFinished: aGame [
 
-	[ aGame hasEnded ] whileFalse: [ aGame playNextTurn ].
+	[ aGame hasEnded ] whileFalse: [ aGame playNextTurn ]
 ]
 
 { #category : #asserting }
@@ -39,103 +44,16 @@ LaScalonetaGameTest >> should: block raise: expectedErrorClass withMessage: expe
 ]
 
 { #category : #tests }
-LaScalonetaGameTest >> testEveryoneGoesBackToTile1WhenJorgeLandsOnAnAtomicBombEffect [
-
-	| aGame aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: { NoEffect new. AtomicBombEffect new. NoEffect new. NoEffect new. NoEffect new } andParsecs: 5.
-
-   aDie1 := LoadedDie with: 2.
-
-   aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Jorge'. 'Julian'} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 2.
-				
-	 aGame playNextTurn.
-	 aGame playNextTurn.
-	 aGame playNextTurn.
-	 aGame playNextTurn.
-	 aGame playNextTurn.
-	
-	 self assert: (aGame positionOf:'Julian')tileNumber equals: 1.
-	 self assert: (aGame positionOf:'Julian')lap equals: 1.
-	 self assert: (aGame positionOf:'Julian')tileNumber equals: 1.
-	 self assert: (aGame positionOf:'Jorge')lap equals: 2.
-]
-
-{ #category : #running }
-LaScalonetaGameTest >> testFinalPositionOfPlayersCorrespondsWithTheActualFinalPositions [
+LaScalonetaGameTest >> testAskingForTheWinnerWhenTheGameHasNotEndedThrowsAnErrorMessage [
 
 	| aGame aDiceCup aBoard aDie1 |
-	
-	aBoard := Board withTiles: { NoEffect new. NoEffect new. NoEffect new } andParsecs: 3.
-
-	aDie1 := LoadedDie with: 3.
-	aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame
-		         playedBy: { 'Jorge'. 'Julian' }
-		         on: aBoard
-		         rolling: aDiceCup
-					numberOfLaps: 2.
-
-	aGame playNextTurn. 
-	aGame playNextTurn. 
-	
-	self assert: ( aGame positionOf: 'Jorge' ) tileNumber equals: 1.
-	self assert: ( aGame positionOf: 'Julian' ) tileNumber equals: 1.
-	self assert: ( aGame positionOf: 'Jorge' ) lap equals: 2.
-	self assert: ( aGame positionOf: 'Julian' ) lap equals: 2.
-
-	aGame playNextTurn. 
-
-	self assert: ( aGame positionOf: 'Jorge' ) tileNumber equals: 3.
-	self assert: ( aGame positionOf: 'Julian' ) tileNumber equals: 1.
-	self assert: ( aGame positionOf: 'Jorge' ) lap equals: 2.
-	self assert: ( aGame positionOf: 'Julian' ) lap equals: 2.
-	
-	self assert: aGame hasEnded
-
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testGameHasEndedAsOnePlayerReachedTheEnd [
-
-	| aGame aDiceCup aBoard aDie1 |
-	
-	aBoard := Board withTiles: { NoEffect new. NoEffect new. NoEffect new } andParsecs: 3.
-
-	aDie1 := LoadedDie with: 3.
-	aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame
-		         playedBy: { 'Jorge'. 'Julian' }
-		         on: aBoard
-		         rolling: aDiceCup
-					numberOfLaps: 2.
-
-	self deny: (aGame hasEnded).
-	
-	aGame playNextTurn. 
-	aGame playNextTurn. 	
-	aGame playNextTurn.
-			
-	self assert: aGame hasEnded.
-	self assert: ((aGame positionOf: 'Jorge') tileNumber) equals: aGame board tiles size
-	
-
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testGameHasNotEndedAsNoPlayerReachedTheEnd [
-
-	| aGame aDiceCup aBoard aDie1 |
-	
-	aBoard := Board withTiles: { NoEffect new. NoEffect new. NoEffect new. NoEffect new  }andParsecs: 4.
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 4.
 
 	aDie1 := LoadedDie with: 1.
 	aDiceCup := DiceCup withAll: { aDie1 }.
@@ -144,449 +62,693 @@ LaScalonetaGameTest >> testGameHasNotEndedAsNoPlayerReachedTheEnd [
 		         playedBy: { 'Jorge'. 'Julian' }
 		         on: aBoard
 		         rolling: aDiceCup
-					numberOfLaps: 2.
+		         withNumberOfLaps: 2.
 
-	self deny: (aGame hasEnded).
-	
-	aGame playNextTurn. 
-	aGame playNextTurn. 	
-	aGame playNextTurn.
-			
 	self deny: aGame hasEnded.
+
+	self
+		should: [ aGame winner ]
+		raise: Error
+		withMessage: 'There is no winner as the game has not ended yet.'
 ]
 
 { #category : #tests }
-LaScalonetaGameTest >> testHyperJumpEffectListIsIteratedCorrectly [
+LaScalonetaGameTest >> testEveryoneGoesBackToTheFirstPositionOnTheSameLapWhenJorgeLandsOnAnAtomicBombEffect [
 
 	| aGame aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          AtomicBombEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 5.
 
-	aBoard := Board withTiles: { NoEffect new. HyperJumpEffect with: #(1 2 3).  NoEffect new. NoEffect new. NoEffect new. NoEffect new } andParsecs: 3.
-	
-   aDie1 := LoadedDie with: 1.
+	aDie1 := LoadedDie with: 2.
 
-   aDiceCup := DiceCup withAll: { aDie1 }.
+	aDiceCup := DiceCup withAll: { aDie1 }.
 
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Jorge'. 'Julian'} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 2.
-				
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge'. 'Julian' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
 	aGame playNextTurn.
-	
-	self assert: (aGame positionOf:'Jorge')tileNumber equals: 2.
-	self assert: (aGame positionOf:'Jorge')lap equals: 2.
-	
+	aGame playNextTurn.
+	aGame playNextTurn.
+	aGame playNextTurn.
 	aGame playNextTurn.
 
-	self assert: (aGame positionOf:'Julian')tileNumber equals: 6.
-	self assert: (aGame positionOf:'Julian')lap equals: 1.	
+	self assert: (aGame positionOf: 'Julian') tileNumber equals: 1.
+	self assert: (aGame positionOf: 'Julian') lap equals: 1.
+	self assert: (aGame positionOf: 'Julian') tileNumber equals: 1.
+	self assert: (aGame positionOf: 'Jorge') lap equals: 2
 ]
 
 { #category : #tests }
-LaScalonetaGameTest >> testJorgeAndJulianArePlayersOfLaScalonetaGame [
+LaScalonetaGameTest >> testFinalPositionOfSpaceShipsCorrespondsWithTheActualFinalPositions [
 
-	| aGame |
+	| aGame aDiceCup aBoard aDie1 |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 3.
 
-	aGame := self initializeLaScalonetaGame.
-				
-	self assert: aGame spaceShips equals: {'Jorge'. 'Julian'}
+	aDie1 := LoadedDie with: 3.
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge'. 'Julian' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	aGame playNextTurn.
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 1.
+	self assert: (aGame positionOf: 'Julian') tileNumber equals: 1.
+	self assert: (aGame positionOf: 'Jorge') lap equals: 2.
+	self assert: (aGame positionOf: 'Julian') lap equals: 2.
+
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 3.
+	self assert: (aGame positionOf: 'Julian') tileNumber equals: 1.
+	self assert: (aGame positionOf: 'Jorge') lap equals: 2.
+	self assert: (aGame positionOf: 'Julian') lap equals: 2.
+
+	self assert: aGame hasEnded
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testGameHasEndedAsOneSpaceShipReachedTheEnd [
+
+	| aGame aDiceCup aBoard aDie1 |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 3.
+
+	aDie1 := LoadedDie with: 3.
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge'. 'Julian' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	self deny: aGame hasEnded.
+
+	aGame playNextTurn.
+	aGame playNextTurn.
+	aGame playNextTurn.
+
+	self assert: aGame hasEnded.
+	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 3.
+	self assert: (aGame positionOf: 'Jorge') lap equals: 2
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testHyperJumpEffectMValuesCollectionCanNotBeEmpty [
+
+	self
+		should: [ HyperJumpEffect withMValues: #(  ) ]
+		raise: Error
+		withMessage:
+		'HyperJumpEffect can not be initalize with empty collection!'
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testHyperJumpEffectMValuesCollectionCanNotContainsNegativeValues [
+
+	self
+		should: [ HyperJumpEffect withMValues: #( 1 -3 4 ) ]
+		raise: Error
+		withMessage: 'Values of the collection must be positive!'
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testJorgeDoesNotMoveFowardAsTheNumberOfParsecsIsNotEnoughToMoveOneTile [
+
+	| aGame aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          (HyperJumpEffect withMValues: #( 1 )).
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 12.
+
+	aDie1 := LoadedDie with: 1.
+
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 2.
+	self assert: (aGame positionOf: 'Jorge') lap equals: 1.
 ]
 
 { #category : #tests }
 LaScalonetaGameTest >> testJorgeIsNotTheWinnerOfLaScalonetaGameWhenJulianReachesTheEndFirst [
 
 	| aGame aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: { NoEffect new. NoEffect new. NoEffect new. NoEffect new }andParsecs: 4.
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 4.
 	aDie1 := LoadedDie with: 3.
-   aDiceCup := DiceCup withAll: { aDie1 }.
+	aDiceCup := DiceCup withAll: { aDie1 }.
 
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Julian'. 'Jorge'} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 2.
+	aGame := LaScalonetaGame
+		         playedBy: { 'Julian'. 'Jorge' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
 
-	 aGame playNextTurn. 
-	
-	 self deny: aGame winner equals: 'Jorge'
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testJorgeMovesBack4TilesWhenLandingOnAWormholeEffect [
-
-	| aGame aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: { NoEffect new. NoEffect new. NoEffect new. NoEffect new. WormHoleEffect new. NoEffect new }andParsecs: 6.
-
-   aDie1 := LoadedDie with: 4.
-   aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Jorge'} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 2.
-
-	 aGame playNextTurn. 
-	
-	 self assert: (aGame positionOf: 'Jorge') tileNumber equals: 1.
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testJorgeMovesForward4TilesWhenLandingOnASppedUpEffect [
-
-	| aGame aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: { NoEffect new. SpeedUpEffect new. NoEffect new. NoEffect new. NoEffect new. NoEffect new }andParsecs: 6.
-
-   aDie1 := LoadedDie with: 1.
-   aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Jorge'} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 2.
-
-	 aGame playNextTurn. 
-	
-	 self assert: (aGame positionOf: 'Jorge') tileNumber equals: 6.
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testJorgeMovesForwardAccordinglyWhenLandingOnAHyperJumpEffect [
-
-	| aGame aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: { NoEffect new. HyperJumpEffect with: #(1 2 3).  NoEffect new. NoEffect new. NoEffect new. NoEffect new } andParsecs: 3.
-	
-   aDie1 := LoadedDie with: 1.
-
-   aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Jorge'} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 2.
-				
 	aGame playNextTurn.
-	
-	self assert: (aGame positionOf:'Jorge')tileNumber equals: 2.
-	self assert: (aGame positionOf:'Jorge')lap equals: 2.
+
+	self deny: aGame winner equals: 'Jorge'
 ]
 
 { #category : #tests }
-LaScalonetaGameTest >> testJorgeWinsLaScalonetaGameWhenJorgeReachesTheEndFirst [
-
-	| aGame aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: {  NoEffect new. NoEffect new. NoEffect new. NoEffect new }andParsecs: 4.
-
-   aDie1 := LoadedDie with: 3.
-   aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Jorge'. 'Julian'} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 2.
-
-	 aGame playNextTurn.
-	
-	 self assert: aGame winner equals: 'Jorge'
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testJulianMovesBack2PositionsAndBacksAlapWhenJorgeLandsOnAMoonWalkEffect [
-
-	| aGame aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: { MoonWalkEffect withN: -2. NoEffect new. NoEffect new. NoEffect new }andParsecs: 4.
-
-   aDie1 := LoadedDie with: 2.
-
-   aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Jorge'. 'Julian'} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 2.
-				
-	 aGame playNextTurn.
-	 aGame playNextTurn.
-	 aGame playNextTurn.
-	
-	 self assert: (aGame positionOf:'Julian')tileNumber equals: 1.
-	 self assert: (aGame positionOf:'Julian')lap equals: 1.
-	 self assert: (aGame positionOf:'Julian')tileNumber equals: 1.
-	 self assert: (aGame positionOf:'Jorge')lap equals: 2.
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testJulianMovesBack3PositionsWhenJorgeLandsOnAMoonWalkEffect [
-
-	| aGame aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: { MoonWalkEffect withN: -2. NoEffect new. NoEffect new. NoEffect new }andParsecs: 4.
-
-   aDie1 := LoadedDie with: 2.
-
-   aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Jorge'. 'Julian'} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 2.
-				
-	 aGame playNextTurn.
-	 aGame playNextTurn.
-	 aGame playNextTurn.
-	
-	 self assert: (aGame positionOf:'Julian')tileNumber equals: 1.
-	 self assert: (aGame positionOf:'Julian')lap equals: 1.
-	 self assert: (aGame positionOf:'Julian')tileNumber equals: 1.
-	 self assert: (aGame positionOf:'Jorge')lap equals: 2.
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testLaScalonetaGameEndWhenPlayingWithARandomDie [
+LaScalonetaGameTest >> testJorgeIsTheFirstSpaceShipAtSpaceShipsRankingAsHisPositionIsTheClosestToTheGoal [
 
 	| aGame aDiceCup aBoard aDie1 |
-
-	aBoard := Board withTiles: { NoEffect new. NoEffect new. NoEffect new. NoEffect new } andParsecs: 2.
-
-   aDie1 := RandomDie with: 3.
-   aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Julian'. 'Jorge'} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 2.
-
-	self deny: aGame hasEnded.
-
-	self playUntilFinished: aGame.
-	
-	self assert: aGame hasEnded
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testLaScalonetaGameMustHaveAtLeastOnePlayer [
-
-	| aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: {NoEffect new. NoEffect new. NoEffect new}andParsecs: 3.
-	
-	aDie1 := LoadedDie with: 1.
-	aDiceCup := DiceCup withAll: { aDie1 }.
-
-	self
-		should: [ LaScalonetaGame 
-				playedBy: ( {} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 2.
-			]
-		raise: Error
-		withMessage: 'La Scaloneta Game must have at least one spaceship!'
-
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testLaScalonetaGameMustHaveTwoOrMoreLaps [
-	| aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: {NoEffect new. NoEffect new. NoEffect new} andParsecs: 3.
-	
-	aDie1 := LoadedDie with: 1.
-	aDiceCup := DiceCup withAll: { aDie1 }.
-
-	self
-		should: [ LaScalonetaGame 
-				playedBy: ( {'Player1'. 'Player2'} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 1.
-			]
-		raise: Error
-		withMessage: 'La Scaloneta Game must have two or more laps!'
-
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testPlayerMovesThreeTilesFowardWhenRollingResultEqualsToThree [
-
-	| aGame aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: {  NoEffect new. NoEffect new. NoEffect new. NoEffect new } andParsecs: 4.
-	
-	aDie1 := LoadedDie with: 3.
-	aDiceCup := DiceCup withAll: { aDie1 }.
-	
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Jorge'. 'Julian'} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 2.
-				
-	aGame playNextTurn.  	
-
-	self assert: ( aGame positionOf: 'Jorge' ) tileNumber equals: 4.	
-				
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testPlayerStartsAtLapOne [
-
-	| aGame |
-
-	aGame := self initializeLaScalonetaGame.
-
-	self assert: ( aGame positionOf: 'Jorge' ) lap equals: 1.
-	self assert: ( aGame positionOf: 'Julian' ) lap equals: 1
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testPlayerStartsAtTileNumberOne [
-
-	| aGame |
-
-	aGame := self initializeLaScalonetaGame.
-
-	self assert: ( aGame positionOf: 'Jorge' ) tileNumber equals: 1.
-	self assert: ( aGame positionOf: 'Julian' ) tileNumber equals: 1
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testPlayingAfterWinningIsNotAllowed [
-
-	| aGame aBoard aDie1 aDiceCup |
-
-	aBoard := Board withTiles: { NoEffect new. NoEffect new. NoEffect new } andParsecs: 3.
-	
-	aDie1 := LoadedDie with: 3.
-	aDiceCup := DiceCup withAll: { aDie1 }.
-
-	aGame := LaScalonetaGame 
-				playedBy: ( {'Jorge'. 'Julian'} )
-				on: aBoard
-				rolling: aDiceCup
-				numberOfLaps: 2.
-				
-	self deny: (aGame hasEnded).
-	self assert: ( aGame positionOf: 'Jorge' ) tileNumber equals: 1.	
-	self assert: ( aGame positionOf: 'Julian' ) tileNumber equals: 1.	
-			
-	aGame playNextTurn. 	
-		
-	self assert: ( aGame positionOf: 'Jorge' ) tileNumber equals: 1.	
-	self assert: ( aGame positionOf: 'Julian' ) tileNumber equals: 1.
-	
-	aGame playNextTurn. 
-	aGame playNextTurn. 
-	
-	self assert: (aGame hasEnded).
-	
-	self
-		should: [aGame playNextTurn]
-		raise: Error
-		withMessage: 'La Scaloneta Game has already ended!'
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testScalonetaGamePlayedWithRandomBoard [
-	|tilesCollection board aGame pool aDie1 aDiceCup|
-	
-	pool := EffectPool withEffects: {NoEffect new. MoonWalkEffect withN: -2. HyperJumpEffect with: #(1 2 3). AtomicBombEffect new. WormHoleEffect new. } andProbabilities: {40. 10. 8. 20. 2. 20.}.
-	tilesCollection := pool randomCollectionOfEffectsWithLength: 5.
-	
-	board := Board withTiles: tilesCollection andParsecs: 2.
-	
-	aDie1 := LoadedDie with: 7.
-   aDiceCup := DiceCup withAll: { aDie1 }.
-
-   aGame := LaScalonetaGame
-                 playedBy: { 'Jorge'. 'Julian' }
-                 on: board
-                 rolling: aDiceCup
-                    numberOfLaps: 2.
-
-	self playUntilFinished: aGame.	
-	
-	self assert: aGame hasEnded.
-
-
-	
-	
-	
-]
-
-{ #category : #tests }
-LaScalonetaGameTest >> testSpaceShipsRanking [
-
-	| aGame aDiceCup aBoard aDie1 |
-	
-	aBoard := Board withTiles: { NoEffect new. NoEffect new. } andParsecs: 3.
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 3.
 
 	aDie1 := LoadedDie with: 1.
 	aDiceCup := DiceCup withAll: { aDie1 }.
 
 	aGame := LaScalonetaGame
-		         playedBy: { 'Jorge'. 'Julian'. 'Lucas'. }
+		         playedBy: { 'Jorge'. 'Julian'. 'Lucas' }
 		         on: aBoard
 		         rolling: aDiceCup
-					numberOfLaps: 2.
-					
+		         withNumberOfLaps: 2.
+
 	aGame playNextTurn.
 	aGame playNextTurn.
 	aGame playNextTurn.
 	aGame playNextTurn.
-	
-	self assert: (aGame positionsRanking at: 1)spaceShip equals: 'Jorge'.
-	self assert: (aGame positionsRanking at: 1)tileNumber equals: 1.
-	self assert: (aGame positionsRanking at: 1)lap equals: 2.
-	
-	self assert: (aGame positionsRanking at: 2)spaceShip equals: 'Lucas'.
-	self assert: (aGame positionsRanking at: 2)tileNumber equals: 2.
-	self assert: (aGame positionsRanking at: 2)lap equals: 1.
-	
-	self assert: (aGame positionsRanking at: 3)spaceShip equals: 'Julian'.
-	self assert: (aGame positionsRanking at: 3)tileNumber equals: 2.
-	self assert: (aGame positionsRanking at: 3)lap equals: 1.
+
+	self assert: aGame positionsRanking first spaceShip equals: 'Jorge'.
+	self assert: aGame positionsRanking first tileNumber equals: 1.
+	self assert: aGame positionsRanking first lap equals: 2.
 ]
 
 { #category : #tests }
-LaScalonetaGameTest >> testThereIsNoWinnerAsTheGameHasNotEnded [
+LaScalonetaGameTest >> testJorgeMovesBackFourTilesWhenLandingOnAWormholeEffect [
 
-	| aGame aDiceCup aBoard aDie1 |
-	
-	aBoard := Board withTiles: { NoEffect new. NoEffect new. NoEffect new. NoEffect new  } andParsecs: 4.
+	| aGame aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          WormHoleEffect new.
+				          NoEffect new }
+		          andParsecs: 6.
+
+	aDie1 := LoadedDie with: 4.
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 1
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testJorgeMovesForwardFourTilesWhenLandingOnASppedUpEffect [
+
+	| aGame aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          SpeedUpEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 6.
 
 	aDie1 := LoadedDie with: 1.
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 6
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testJorgeMovesForwardOneParsecWhenLandingOnAHyperJumpEffectWithMValueEqualsToOneParsec [
+
+	| aGame aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          (HyperJumpEffect withMValues: #( 1 2 3 )).
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 3.
+
+	aDie1 := LoadedDie with: 1.
+
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 2.
+	self assert: (aGame positionOf: 'Jorge') lap equals: 2
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testJorgeMovesFowardOneParsecAndThenJulianMovesFowardTwoParsecsSinceTheyBothLandedOnAHyperJumpEffectAndOneAndTwoWhereTheFirstValuesOfTheMValuesList [
+
+	| aGame aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          (HyperJumpEffect withMValues: #( 1 2 3 )).
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 3.
+
+	aDie1 := LoadedDie with: 1.
+
 	aDiceCup := DiceCup withAll: { aDie1 }.
 
 	aGame := LaScalonetaGame
 		         playedBy: { 'Jorge'. 'Julian' }
 		         on: aBoard
 		         rolling: aDiceCup
-					numberOfLaps: 2.
+		         withNumberOfLaps: 2.
 
-	self deny: (aGame hasEnded).
-	
-	aGame playNextTurn. 
-	aGame playNextTurn. 	
 	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 2.
+	self assert: (aGame positionOf: 'Jorge') lap equals: 2.
+
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Julian') tileNumber equals: 6.
+	self assert: (aGame positionOf: 'Julian') lap equals: 1
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testJorgeMovesFowardOneParsecThenJulianMovesFowardTwoParsecsAndFinallyHernanMovesFowardOneParsecAgainWhenLadingOnAHyperJumpEffectInitializeWithATwoMValuesList [
+
+	| aGame aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          (HyperJumpEffect withMValues: #( 2 3 )).
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 3.
+
+	aDie1 := LoadedDie with: 1.
+
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge'. 'Julian'. 'Hernan' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 2.
+	self assert: (aGame positionOf: 'Jorge') lap equals: 2.
+
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Julian') tileNumber equals: 6.
+	self assert: (aGame positionOf: 'Julian') lap equals: 1.
 	
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Hernan') tileNumber equals: 2.
+	self assert: (aGame positionOf: 'Hernan') lap equals: 2
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testJorgeWinsLaScalonetaGameWhenJorgeReachesTheEndFirst [
+
+	| aGame aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 4.
+
+	aDie1 := LoadedDie with: 3.
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge'. 'Julian' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	aGame playNextTurn.
+
+	self assert: aGame winner equals: 'Jorge'
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testJulianIsTheThirdSpaceShipAtSpaceShipsRankingAsHisPositionIsTheThirdClosestToTheGoal [
+
+	| aGame aDiceCup aBoard aDie1 |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 3.
+
+	aDie1 := LoadedDie with: 1.
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge'. 'Julian'. 'Lucas' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	aGame playNextTurn.
+	aGame playNextTurn.
+	aGame playNextTurn.
+	aGame playNextTurn.
+
+	self assert: aGame positionsRanking third spaceShip equals: 'Julian'.
+	self assert: aGame positionsRanking third tileNumber equals: 2.
+	self assert: aGame positionsRanking third lap equals: 1.
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testJulianMovesBackThreePositionsWhenJorgeLandsOnAMoonWalkEffect [
+
+	| aGame aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          (MoonWalkEffect withN: -2).
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 4.
+
+	aDie1 := LoadedDie with: 2.
+
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge'. 'Julian' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	aGame playNextTurn.
+	aGame playNextTurn.
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Julian') tileNumber equals: 1.
+	self assert: (aGame positionOf: 'Julian') lap equals: 1.
+	self assert: (aGame positionOf: 'Julian') tileNumber equals: 1.
+	self assert: (aGame positionOf: 'Jorge') lap equals: 2
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testJulianMovesBackTwoPositionsAndBacksALapWhenJorgeLandsOnAMoonWalkEffect [
+
+	| aGame aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          (MoonWalkEffect withN: -2).
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 4.
+
+	aDie1 := LoadedDie with: 2.
+
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge'. 'Julian' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	aGame playNextTurn.
+	aGame playNextTurn.
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Julian') tileNumber equals: 1.
+	self assert: (aGame positionOf: 'Julian') lap equals: 1.
+	self assert: (aGame positionOf: 'Julian') tileNumber equals: 1.
+	self assert: (aGame positionOf: 'Jorge') lap equals: 2
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testLaScalonetaGameEndWhenPlayingWithARandomDie [
+
+	| aGame aDiceCup aBoard aDie1 |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 2.
+
+	aDie1 := RandomDie with: 3.
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Julian'. 'Jorge' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	self deny: aGame hasEnded.
+
+	self playUntilFinished: aGame.
+
+	self assert: aGame hasEnded
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testLaScalonetaGameMustHaveAtLeastOneSpaceShip [
+
+	| aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 3.
+
+	aDie1 := LoadedDie with: 1.
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
 	self
 		should: [ 
-				aGame winner
-				]
+			LaScalonetaGame
+				playedBy: {  }
+				on: aBoard
+				rolling: aDiceCup
+				withNumberOfLaps: 2 ]
 		raise: Error
-		withMessage: 'There is no winner as the game has not ended yet.'
+		withMessage: 'La Scaloneta Game must have at least one spaceship!'
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testLaScalonetaGameMustHaveOneOrMoreLaps [
+
+	| aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 3.
+
+	aDie1 := LoadedDie with: 1.
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	self
+		should: [ 
+			LaScalonetaGame
+				playedBy: { 'Player1'. 'Player2' }
+				on: aBoard
+				rolling: aDiceCup
+				withNumberOfLaps: 0 ]
+		raise: Error
+		withMessage: 'La Scaloneta Game must have one or more laps!'
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testPlayingAfterWinningIsNotAllowed [
+
+	| aGame aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 3.
+
+	aDie1 := LoadedDie with: 3.
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge'. 'Julian' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	self deny: aGame hasEnded.
+	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 1.
+	self assert: (aGame positionOf: 'Julian') tileNumber equals: 1.
+
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 1.
+	self assert: (aGame positionOf: 'Julian') tileNumber equals: 1.
+
+	aGame playNextTurn.
+	aGame playNextTurn.
+
+	self assert: aGame hasEnded.
+
+	self
+		should: [ aGame playNextTurn ]
+		raise: Error
+		withMessage: 'La Scaloneta Game has already ended!'
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testScalonetaGamePlayedWithRandomBoard [
+
+	| tilesCollection board aGame pool aDie1 aDiceCup |
+	pool := EffectPool
+		        withEffects: { 
+				        NoEffect new.
+				        (MoonWalkEffect withN: -2).
+				        (HyperJumpEffect withMValues: #( 1 2 3 )).
+				        AtomicBombEffect new.
+				        WormHoleEffect new }
+		        andProbabilities: { 40. 10. 8. 20. 2. 20 }.
+	tilesCollection := pool randomCollectionOfEffectsWithLength: 5.
+
+	board := Board withTiles: tilesCollection andParsecs: 2.
+
+	aDie1 := LoadedDie with: 7.
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge'. 'Julian' }
+		         on: board
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	self playUntilFinished: aGame.
+
+	self assert: aGame hasEnded
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testSpaceShipMovesThreeTilesFowardWhenRollingResultEqualsToThree [
+
+	| aGame aBoard aDie1 aDiceCup |
+	aBoard := Board
+		          withTiles: { 
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new.
+				          NoEffect new }
+		          andParsecs: 4.
+
+	aDie1 := LoadedDie with: 3.
+	aDiceCup := DiceCup withAll: { aDie1 }.
+
+	aGame := LaScalonetaGame
+		         playedBy: { 'Jorge'. 'Julian' }
+		         on: aBoard
+		         rolling: aDiceCup
+		         withNumberOfLaps: 2.
+
+	aGame playNextTurn.
+
+	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 4
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testSpaceShipStartsAtLapOne [
+
+	| aGame |
+	aGame := self laScalonetaGamePlayedByJorgeAndJulianWithALoadedDieWithOneOnABoardOfFourNoEffectTilesAndTwoParsecsDuringTwoLaps.
+
+	self assert: (aGame positionOf: 'Jorge') lap equals: 1.
+	self assert: (aGame positionOf: 'Julian') lap equals: 1
+]
+
+{ #category : #tests }
+LaScalonetaGameTest >> testSpaceShipStartsAtTileNumberOne [
+
+	| aGame |
+	aGame := self laScalonetaGamePlayedByJorgeAndJulianWithALoadedDieWithOneOnABoardOfFourNoEffectTilesAndTwoParsecsDuringTwoLaps.
+
+	self assert: (aGame positionOf: 'Jorge') tileNumber equals: 1.
+	self assert: (aGame positionOf: 'Julian') tileNumber equals: 1
 ]


### PR DESCRIPTION
…psRanking, first/second/third en lugar de at: ..., se mejora la declaritividad en los nombres de los mensajes y tests, uso de #ifEmpty, se cambia "player" por "spaceShip", se elimina #itsMyTurn, #and y #or en lugar de & o |